### PR TITLE
Add Jest testing setup and CI workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,18 @@
+name: CI
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: npm ci
+      - run: npm test

--- a/package.json
+++ b/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "break-reminder-extension",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "test": "jest"
+  },
+  "devDependencies": {
+    "jest": "^29.7.0"
+  }
+}

--- a/tests/popup.test.js
+++ b/tests/popup.test.js
@@ -1,0 +1,39 @@
+const fs = require('fs');
+const path = require('path');
+
+describe('popup behavior', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    document.body.innerHTML = fs.readFileSync(
+      path.join(__dirname, '..', 'popup.html'),
+      'utf8'
+    );
+
+    global.chrome = {
+      storage: {
+        local: {
+          get: jest.fn((keys, cb) => cb({})),
+          set: jest.fn((data, cb) => cb()),
+        },
+      },
+      runtime: {
+        sendMessage: jest.fn(),
+      },
+    };
+
+    require('../popup.js');
+    document.dispatchEvent(new Event('DOMContentLoaded'));
+  });
+
+  test('shows active status after starting', () => {
+    const interval = document.getElementById('interval');
+    const startBtn = document.getElementById('start');
+
+    interval.value = '30';
+    startBtn.click();
+
+    expect(document.getElementById('status').textContent).toBe(
+      'Break reminders are active.'
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- set up Jest for testing with new package.json
- add placeholder popup behavior test
- configure GitHub Actions to run npm test

## Testing
- `npm test` (fails: jest: not found)


------
https://chatgpt.com/codex/tasks/task_e_68b972a81d8083289233d9394e365b99