### PR TITLE
feat: add onboarding and basic test setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+

--- a/PRIVACY_POLICY.md
+++ b/PRIVACY_POLICY.md
@@ -1,0 +1,7 @@
+# Privacy Policy
+
+Break Reminder does not collect, store or transmit any personal data.
+All settings are saved locally in your browser and never leave your device.
+
+If you have any questions about this policy, please contact [support@example.com](mailto:support@example.com).
+

--- a/README.md
+++ b/README.md
@@ -1,0 +1,13 @@
+# Break Reminder
+
+A Chrome extension that helps you stay healthy by nudging you to take periodic breaks.
+
+## Features
+- Set custom break intervals
+- Toggle reminders on or off with a single switch
+- Countdown display and badge timer so you always know when the next break is due
+
+## Support
+Questions or feedback? Contact us at [support@example.com](mailto:support@example.com).
+
+See the [Privacy Policy](PRIVACY_POLICY.md) for details on data handling.

--- a/manifest.json
+++ b/manifest.json
@@ -6,24 +6,31 @@
   "action": {
     "default_popup": "popup.html",
     "default_icon": {
-      "16": "icons/icon_16.png",
-      "32": "icons/icon_32.png",
-      "48": "icons/icon_48.png",
-      "128": "icons/icon_128.png"
+      "16": "icon_16.png",
+      "32": "icon_32.png",
+      "48": "icon_48.png",
+      "128": "icon_128.png"
     }
   },
   "background": {
     "service_worker": "background.js"
   },
+  "web_accessible_resources": [
+    {
+      "resources": ["onboarding.html", "PRIVACY_POLICY.md"],
+      "matches": ["<all_urls>"]
+    }
+  ],
   "permissions": [
     "alarms",
     "notifications",
     "storage"
   ],
   "icons": {
-    "16": "icons/icon_16.png",
-    "32": "icons/icon_32.png",
-    "48": "icons/icon_48.png",
-    "128": "icons/icon_128.png"
+    "16": "icon_16.png",
+    "32": "icon_32.png",
+    "48": "icon_48.png",
+    "128": "icon_128.png"
   }
 }
+

--- a/onboarding.html
+++ b/onboarding.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8" />
+    <title>Welcome to Break Reminder</title>
+    <style>
+      body { font-family: Arial, sans-serif; padding: 20px; }
+      h1 { font-size: 22px; }
+      p { margin-bottom: 12px; }
+    </style>
+  </head>
+  <body>
+    <h1>Welcome!</h1>
+    <p>Break Reminder helps you stay healthy by prompting periodic breaks.</p>
+    <p>Click the extension icon in the toolbar to set your interval and enable reminders.</p>
+    <p><a href="PRIVACY_POLICY.md" target="_blank">Privacy Policy</a></p>
+  </body>
+</html>
+

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "break-reminder-extension",
+  "version": "1.0.0",
+  "description": "Chrome extension reminding users to take breaks.",
+  "license": "MIT",
+  "devDependencies": {
+    "jest": "^29.0.0"
+  },
+  "scripts": {
+    "test": "jest"
+  }
+}
+

--- a/popup.html
+++ b/popup.html
@@ -6,40 +6,100 @@
     <style>
       body {
         font-family: Arial, sans-serif;
-        padding: 10px;
-        width: 220px;
+        width: 240px;
+        padding: 12px;
+        background: linear-gradient(135deg, #e0f7fa, #fff);
       }
       h3 {
         margin-top: 0;
-        font-size: 16px;
+        font-size: 18px;
+        text-align: center;
       }
-      label,
-      input {
-        display: block;
-        margin-bottom: 5px;
+      .field {
+        margin-bottom: 12px;
+      }
+      label {
+        font-size: 13px;
       }
       input[type="number"] {
         width: 100%;
+        padding: 6px;
         box-sizing: border-box;
       }
-      button {
-        margin-top: 8px;
-        width: 100%;
+      .switch {
+        position: relative;
+        display: inline-block;
+        width: 40px;
+        height: 20px;
+      }
+      .switch input {
+        opacity: 0;
+        width: 0;
+        height: 0;
+      }
+      .slider {
+        position: absolute;
+        cursor: pointer;
+        top: 0;
+        left: 0;
+        right: 0;
+        bottom: 0;
+        background-color: #ccc;
+        transition: 0.4s;
+        border-radius: 20px;
+      }
+      .slider:before {
+        position: absolute;
+        content: '';
+        height: 16px;
+        width: 16px;
+        left: 2px;
+        bottom: 2px;
+        background-color: white;
+        transition: 0.4s;
+        border-radius: 50%;
+      }
+      input:checked + .slider {
+        background-color: #4caf50;
+      }
+      input:checked + .slider:before {
+        transform: translateX(20px);
       }
       #status {
-        margin-top: 10px;
-        font-size: 12px;
-        color: #555;
+        font-size: 13px;
+        text-align: center;
+        margin-top: 8px;
+      }
+      #countdown {
+        text-align: center;
+        font-size: 14px;
+        margin-top: 4px;
+      }
+      .toggle-row {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
       }
     </style>
   </head>
   <body>
     <h3>Break Reminder</h3>
-    <label for="interval">Interval (minutes):</label>
-    <input id="interval" type="number" min="1" value="60" />
-    <button id="start">Start</button>
-    <button id="stop">Stop</button>
+    <div class="field">
+      <label for="interval">Interval (minutes)</label>
+      <input id="interval" type="number" min="1" value="60" />
+    </div>
+    <div class="field toggle-row">
+      <span>Enable</span>
+      <label class="switch">
+        <input id="toggle" type="checkbox" />
+        <span class="slider"></span>
+      </label>
+    </div>
+    <p id="countdown">Next break in: --</p>
     <p id="status"></p>
+    <p style="text-align: center; font-size: 12px;">
+      <a href="PRIVACY_POLICY.md" target="_blank">Privacy Policy</a>
+    </p>
     <script src="popup.js"></script>
   </body>
 </html>

--- a/popup.js
+++ b/popup.js
@@ -1,18 +1,18 @@
 /*
  * Popup script for Break Reminder extension.
  *
- * Provides a simple UI that allows the user to set the interval between break
- * notifications, start the reminder schedule, and stop it. The current
- * interval and activation state are stored in chrome.storage.local so they
- * persist across browser sessions. Communication with the background service
- * worker is done via messages to start or stop alarms.
+ * Provides a user-friendly interface to enable or disable break reminders,
+ * configure the interval, and display a countdown until the next break.
+ * Settings are persisted in chrome.storage.local.
  */
 
 document.addEventListener('DOMContentLoaded', () => {
   const intervalInput = document.getElementById('interval');
-  const startBtn = document.getElementById('start');
-  const stopBtn = document.getElementById('stop');
+  const toggle = document.getElementById('toggle');
   const statusEl = document.getElementById('status');
+  const countdownEl = document.getElementById('countdown');
+
+  let countdownId;
 
   // Load saved settings and update UI accordingly
   chrome.storage.local.get(['interval', 'active'], (data) => {
@@ -22,40 +22,67 @@ document.addEventListener('DOMContentLoaded', () => {
     updateStatus(Boolean(data.active));
   });
 
-  // Handle start button
-  startBtn.addEventListener('click', () => {
+  // Handle toggle switch
+  toggle.addEventListener('change', () => {
     const mins = parseInt(intervalInput.value, 10);
-    if (!isNaN(mins) && mins > 0) {
-      chrome.storage.local.set({ interval: mins, active: true }, () => {
-        // Tell background script to schedule the alarm
-        chrome.runtime.sendMessage({ type: 'start', interval: mins });
-        updateStatus(true);
-      });
+    if (toggle.checked) {
+      if (!isNaN(mins) && mins > 0) {
+        chrome.storage.local.set({ interval: mins, active: true }, () => {
+          chrome.runtime.sendMessage({ type: 'start', interval: mins });
+          updateStatus(true);
+        });
+      } else {
+        statusEl.textContent = 'Please enter a valid number of minutes.';
+        toggle.checked = false;
+      }
     } else {
-      statusEl.textContent = 'Please enter a valid number of minutes.';
+      chrome.storage.local.set({ active: false }, () => {
+        chrome.runtime.sendMessage({ type: 'stop' });
+        updateStatus(false);
+      });
     }
-  });
-
-  // Handle stop button
-  stopBtn.addEventListener('click', () => {
-    chrome.storage.local.set({ active: false }, () => {
-      // Tell background script to clear any existing alarms
-      chrome.runtime.sendMessage({ type: 'stop' });
-      updateStatus(false);
-    });
   });
 
   /**
-   * Update the status message in the popup to reflect whether the reminder
-   * schedule is active or stopped.
-   *
-   * @param {boolean} active Whether reminders are currently active
+   * Update the status message and countdown depending on whether reminders
+   * are active.
+   * @param {boolean} active
    */
   function updateStatus(active) {
+    toggle.checked = active;
     if (active) {
       statusEl.textContent = 'Break reminders are active.';
+      startCountdown();
     } else {
       statusEl.textContent = 'Break reminders are stopped.';
+      stopCountdown();
     }
   }
+
+  function startCountdown() {
+    stopCountdown();
+    updateCountdown();
+    countdownId = setInterval(updateCountdown, 1000);
+  }
+
+  function stopCountdown() {
+    clearInterval(countdownId);
+    countdownEl.textContent = 'Next break in: --';
+  }
+
+  function updateCountdown() {
+    chrome.alarms.get('breakReminder', (alarm) => {
+      if (alarm) {
+        const diff = alarm.scheduledTime - Date.now();
+        if (diff > 0) {
+          const minutes = Math.floor(diff / 60000);
+          const seconds = Math.floor((diff % 60000) / 1000);
+          countdownEl.textContent = `Next break in: ${minutes}m ${seconds}s`;
+        } else {
+          countdownEl.textContent = 'Next break soon...';
+        }
+      }
+    });
+  }
 });
+

--- a/tests/basic.test.js
+++ b/tests/basic.test.js
@@ -1,0 +1,4 @@
+test('placeholder', () => {
+  expect(true).toBe(true);
+});
+


### PR DESCRIPTION
## Summary
- introduce onboarding page opened on first install for clearer user guidance
- expose onboarding and policy pages via web accessible resources
- set up Jest testing scaffold with placeholder test
- remove screenshot asset and restore icon paths to avoid binary files

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/jest)*
- `npm test` *(fails: sh: 1: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b6ae769afc8328b54130254553833e