### PR TITLE
Add snooze option to break reminder

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,3 +6,4 @@ A Chrome extension that helps you stay healthy by nudging you to take periodic b
 - Set custom break intervals
 - Toggle reminders on or off with a single switch
 - Countdown display and badge timer so you always know when the next break is due
+- Snooze a reminder or stop notifications directly from the browser notification

--- a/tests/basic.test.js
+++ b/tests/basic.test.js
@@ -1,4 +1,0 @@
-test('placeholder', () => {
-  expect(true).toBe(true);
-});
-

--- a/tests/schedule.test.js
+++ b/tests/schedule.test.js
@@ -1,0 +1,33 @@
+describe('scheduleBreakAlarm', () => {
+  let scheduleBreakAlarm;
+
+  beforeEach(() => {
+    jest.resetModules();
+    const now = Date.now();
+    global.chrome = {
+      alarms: {
+        create: jest.fn(),
+        get: jest.fn((name, cb) => cb({ scheduledTime: now + 60000 })),
+        clear: jest.fn(),
+      },
+      action: {
+        setBadgeText: jest.fn(),
+        setBadgeBackgroundColor: jest.fn(),
+      },
+      runtime: { onInstalled: { addListener: jest.fn() }, onStartup: { addListener: jest.fn() }, onMessage: { addListener: jest.fn() } },
+      tabs: { create: jest.fn() },
+      notifications: { onButtonClicked: { addListener: jest.fn() }, create: jest.fn(), clear: jest.fn() },
+      storage: { local: { get: jest.fn(), set: jest.fn() } },
+    };
+    scheduleBreakAlarm = require('../background').scheduleBreakAlarm;
+  });
+
+  test('uses provided initial delay', () => {
+    scheduleBreakAlarm(30, 5);
+    expect(chrome.alarms.create).toHaveBeenCalledWith('breakReminder', {
+      delayInMinutes: 5,
+      periodInMinutes: 30,
+    });
+  });
+});
+


### PR DESCRIPTION
## Summary
- allow snoozing or stopping reminders directly from notification
- support specifying initial delay when scheduling alarms
- document snooze feature and add unit test for alarm scheduling

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/jest)*
- `npm test` *(fails: sh: 1: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b9b854625883288c607a91d8084e95